### PR TITLE
Print cgroup in logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 23 * * 5' # Every Friday at 23:00
+  # schedule:
+  #   - cron: '0 23 * * 5' # Every Friday at 23:00
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ sudo journalctl -u earlyoom | grep sending
 Example output for above test command (`tail /dev/zero`) will look like: 
 
 ```
-Feb 20 10:59:34 debian earlyoom[10231]: sending SIGTERM to process 7378 uid 1000 "tail": oom_score 156, VmRSS 4962 MiB
+Feb 20 10:59:34 debian earlyoom[10231]: sending SIGTERM to process 7378 uid 1000 "tail": oom_score 156, VmRSS 4962 MiB, cgroup "/user.slice/user-1002.slice/session-6.scope
 ```
 
 > For older versions of `earlyoom`, use: 

--- a/kill.c
+++ b/kill.c
@@ -95,6 +95,7 @@ static void notify_ext(const char* script, const procinfo_t* victim)
     setenv("EARLYOOM_UID", uid_str, 1);
     setenv("EARLYOOM_NAME", victim->name, 1);
     setenv("EARLYOOM_CMDLINE", victim->cmdline, 1);
+    setenv("EARLYOOM_CGROUP", victim->cgroup, 1);
 
     execl(script, script, NULL);
     warn("%s: exec %s failed: %s\n", __func__, script, strerror(errno));
@@ -415,6 +416,13 @@ void fill_informative_fields(procinfo_t* cur)
             cur->uid = res;
         }
     }
+
+    if (strlen(cur->cgroup) == 0) {
+        int res = get_cgroup(cur->pid, cur->cgroup, sizeof(cur->cgroup));
+        if (res < 0) {
+            debug("%s: pid %d: error reading cgroup: %s\n", __func__, cur->pid, strerror(-res));
+        }
+    }
 }
 
 // debug_print_procinfo pretty-prints the process information in `cur`.
@@ -536,9 +544,9 @@ void kill_process(const poll_loop_args_t* args, int sig, const procinfo_t* victi
     }
     // sig == 0 is used as a self-test during startup. Don't notify the user.
     if (sig != 0 || enable_debug) {
-        warn("sending %s to process %d uid %d \"%s\": oom_score %d, VmRSS %lld MiB, cmdline \"%s\"\n",
+        warn("sending %s to process %d uid %d \"%s\": oom_score %d, VmRSS %lld MiB, cmdline \"%s\", cgroup \"%s\"\n",
             sig_name, victim->pid, victim->uid, victim->name, victim->oom_score, victim->VmRSSkiB / 1024,
-            victim->cmdline);
+            victim->cmdline, victim->cgroup);
     }
 
     int res = kill_wait(args, victim->pid, sig);

--- a/meminfo.c
+++ b/meminfo.c
@@ -282,10 +282,10 @@ int get_cgroup(int pid, char* out, size_t outlen)
         return -errno;
     }
 
-    char line[256];
+    char line[PATH_LEN];
     while (fgets(line, sizeof(line), f)) {
         int id;
-        char cgroup_path[256];
+        char cgroup_path[PATH_LEN];
 
         //  Strip newline and null terminate
         size_t len = strlen(line);

--- a/meminfo.h
+++ b/meminfo.h
@@ -32,6 +32,7 @@ typedef struct procinfo {
     pid_stat_t stat;
     char name[PATH_LEN];
     char cmdline[PATH_LEN];
+    char cgroup[PATH_LEN];
 } procinfo_t;
 
 // placeholder value for numeric fields
@@ -45,5 +46,6 @@ int get_oom_score_adj(const int pid, int* out);
 int get_comm(int pid, char* out, size_t outlen);
 int get_uid(int pid);
 int get_cmdline(int pid, char* out, size_t outlen);
+int get_cgroup(int pid, char* out, size_t outlen);
 
 #endif

--- a/testsuite_c_wrappers.go
+++ b/testsuite_c_wrappers.go
@@ -106,6 +106,12 @@ func get_cmdline(pid int) (int, string) {
 	return int(res), C.GoString(cstr)
 }
 
+func get_cgroup(pid int) (int, string) {
+	cstr := C.CString(strings.Repeat("\000", 256))
+	res := C.get_cgroup(C.int(pid), cstr, 256)
+	return int(res), C.GoString(cstr)
+}
+
 func procdir_path(str string) string {
 	if str != "" {
 		cstr := C.CString(str)


### PR DESCRIPTION
It's useful for us to log the container ID when we're killing a process inside it, but more generally applicable to print the cgroup, for example when it's:

A user's process:

> sending SIGTERM to process 8379 uid 0 "memhog": oom_score 1198, VmRSS 6223 MiB, cmdline "memhog 7gb", cgroup "/user.slice/user-1002.slice/session-6.scope"

```
# id -nu 1002
alex
```

A systemd service:

> sending SIGTERM to process 8999 uid 0 "cadvisor": oom_score 1190, VmRSS 6134 MiB, cmdline "cadvisor", cgroup "/system.slice/cadvisor.service"

A docker container:

> sending SIGTERM to process 3841 uid 0 "hog": oom_score 1196, VmRSS 6201 MiB, cmdline "hog", cgroup "/docker/6b9bd6cc42eebde7a9b3398e69dc119649999be410b9decd0aee85ef2a8cac17"